### PR TITLE
Add support for public paths starting with /

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,5 @@ by Reuters Graphics.
      render(<Component />, node)
    }
    ```
+
+   **Note** The plugin only currently supports two types of `publicPath`: "auto" (the same behavior as  if the publicPath is excluded) and a path relative to the root, for example "/assets".

--- a/src/index.js
+++ b/src/index.js
@@ -52,7 +52,7 @@ class HtmlWebpackJsdomPrerenderPlugin {
     let filePath = outputFile
     const publicPath = compilation.options.output?.publicPath
     // Use correct publicPath, for now only for paths beginning with /
-    if (publicPath && publicPath !== 'auto' && publicPath.indexOf('/') === 0) {
+    if (publicPath && publicPath.indexOf('/') === 0) {
       filePath = `${publicPath}${outputFile}`
     }
     const scriptUrl = new URL(filePath, baseUrl).href; // Load source of script as string

--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,13 @@ class HtmlWebpackJsdomPrerenderPlugin {
     const source = asset.source()
 
     const baseUrl = 'http://localhost'
-    const scriptUrl = new URL(outputFile, baseUrl).href
+    let filePath = outputFile
+    const publicPath = compilation.options.output?.publicPath
+    // Use correct publicPath, for now only for paths beginning with /
+    if (publicPath && publicPath !== 'auto' && publicPath.indexOf('/') === 0) {
+      filePath = `${publicPath}${outputFile}`
+    }
+    const scriptUrl = new URL(filePath, baseUrl).href; // Load source of script as string
 
     // Load source of script as string
     const resourceLoader = new StringResourceLoader({ [scriptUrl]: source })


### PR DESCRIPTION
Previously the plugin expected all assets to live at the root, e.g. if the the `chunkFilename` was  `mycode/js/[id].[contenthash].js`, then the resource loader would look for it at `localhost/mycode/js/index.js`, regardless of the `publicPath` set in the webpack config. 

This change makes it so a public path set to a different path starting with `/` will be respected, for example if the assets will be hosted in a separate `/assets` folder. 

More work would be required to get public paths in other formats (e.g. `http://mycdn.com`) to work, but this should solve for our use case.